### PR TITLE
Adding bucket options when creating one.

### DIFF
--- a/charts/minio-manager/README.md
+++ b/charts/minio-manager/README.md
@@ -18,11 +18,11 @@ The following table lists the parameters of this chart.
 | Parameter (* = required parameters)             | Description                                                                | default                    |
 |:------------------------------------------------|:---------------------------------------------------------------------------|:---------------------------|
 |`minioAdminCredentials.secretName` *             | The name of the secret containing the admin credentials. By the default, the following fields need to be provided: `MINIO_ENDPOINT_URL`, `MINIO_SECRET_KEY`, `MINIO_ACCESS_KEY`, `MINIO_USE_SSL`. The name of the field can be override with `minioAdminCredentials.secretKeys`||
-|`users`                                          | List of users that need to be added.)                                      |[]                         |
+|`users`                                          | List of users that need to be added.                                       |[]                         |
 |`users[i].userCredentialsSecret` *               | Name of the secret containing the user credentials                         |                            |
 |`users[i].usernameSecretKey`                     | Key in the secret containing the user's username                           |username                    |
 |`users[i].passwordSecretKey`                     | Key in the secret containing the user's password                           |password                    |
-|`users[i].policy`                                | Name of the policy to use. Can be a policy from the created one. Minio has `readonly`, `writeonly` and `readwrite` default policies applied for all buckets) |"readonly" |
+|`users[i].policy`                                | Name of the policy to use. Can be a policy from the created one. Minio has `readonly`, `writeonly` and `readwrite` default policies applied for all buckets) |readonly |
 |`policies`                                       | List of minio policies to create. Every policy have the following fields: `name`, `readOnly` (boolean selecting if the policy is read only or readwrite. Default to `true`), `buckets` (non empty list of buckets on which the policy apply). ||
 |`minioAdminCredentials.secretKeys.endpointUrl`   | Name of the secret key for the endpoint field                              |MINIO_ENDPOINT_URL          |
 |`minioAdminCredentials.secretKeys.secretKey`     | Name of the secret key for admin secret key field                          |MINIO_SECRET_KEY            |
@@ -34,8 +34,9 @@ The following table lists the parameters of this chart.
 |`imagePullSecrets`                               | List of kubertnetes image pull secrets                                     |                            |
 |`nameOverride`                                   | Override the name of the chart                                             |                            |
 |`fullnameOverride`                               | Override the full name of the chart and component                          |                            |
-|`buckets`                                        | List of buckets to create (list of strings)                                |[]                          |
-
+|`buckets`                                        | Buckets to create as a YAML object. The key is the name of the bucket      |{}                          |
+|`buckets.[name].policy`                          | Policy applied on the bucket for anonymous users. Allowed policies are: [none, download, upload, public] (https://docs.min.io/docs/minio-client-complete-guide.html#policy) |none |
+|`buckets.[name].purge`                           | Purge the bucket if already existent if set to true                        |false                       |
 
 ## Local test
 

--- a/charts/minio-manager/README.md
+++ b/charts/minio-manager/README.md
@@ -11,6 +11,16 @@ This chart only handles the creation of these resources. It does not manage thei
 - Helm 3
 - Minio instance running
 
+### Minio compatibilities
+
+The default minio client version used in this chart has been selected to work with the minio deployment we are using.
+The user of this chart must validate the compatibility of the minio deployment and the minio client used in this chart.
+
+| Chart version  | Default minio client image             | Expected minio deployment              |
+|:---------------|:---------------------------------------|:---------------------------------------|
+|0.2.0           |[minio/mc:RELEASE.2020-04-04T05-28-55Z](https://github.com/minio/mc/releases/tag/RELEASE.2020-04-04T05-28-55Z)   |[minio/minio:RELEASE.2020-04-10T03-34-42Z](https://github.com/minio/minio/releases/tag/RELEASE.2020-04-10T03-34-42Z)|
+
+
 ## Parameters
 
 The following table lists the parameters of this chart.

--- a/charts/minio-manager/ci/test-values.yaml
+++ b/charts/minio-manager/ci/test-values.yaml
@@ -2,9 +2,11 @@
 
 # List of buckets to create
 buckets:
-  - bucket1
-  - bucket2
-  - bucket3
+  bucket1: {}
+  bucket2:
+    purge: true
+  bucket3:
+    policy: upload
 
 # List of users with their accesses
 users:

--- a/charts/minio-manager/templates/minio-manager-global-job.yaml
+++ b/charts/minio-manager/templates/minio-manager-global-job.yaml
@@ -84,10 +84,73 @@ spec:
           - -c
           - -e
           - |
+            # From https://github.com/minio/charts/blob/master/minio/templates/_helper_create_bucket.txt
+            # checkBucketExists ($bucket)
+            # Check if the bucket exists, by using the exit code of `mc ls`
+            checkBucketExists() {
+              BUCKET=$1
+              CMD=$(mc ls minio/$BUCKET > /dev/null 2>&1)
+              return $?
+            }
+
+            # createBucket ($bucket, $policy, $purge, $versioning)
+            # Ensure bucket exists, purging if asked to
+            createBucket() {
+              BUCKET=$1
+              POLICY=$2
+              PURGE=$3
+              VERSIONING=$4
+
+              # Purge the bucket, if set & exists
+              # Since PURGE is user input, check explicitly for `true`
+              if [ $PURGE = true ]; then
+                if checkBucketExists $BUCKET ; then
+                  echo "Purging bucket '$BUCKET'."
+                  set +e ; # don't exit if this fails
+                  mc rm -r --force minio/$BUCKET
+                  set -e ; # reset `e` as active
+                else
+                  echo "Bucket '$BUCKET' does not exist, skipping purge."
+                fi
+              fi
+
+              # Create the bucket if it does not exist
+              if ! checkBucketExists $BUCKET ; then
+                echo "Creating bucket '$BUCKET'"
+                mc mb minio/$BUCKET
+              else
+                echo "Bucket '$BUCKET' already exists."
+              fi
+
+              # Versioning feature available only from RELEASE.2020-07-11T06-07-16Z
+              # https://github.com/minio/minio/releases/tag/RELEASE.2020-07-11T06-07-16Z
+              # Currently using RELEASE.2020-04-04T05-28-55Z
+              # When updated, we can add back the following lines
+              # set versioning for bucket
+              #if [ ! -z $VERSIONING ] ; then
+              #  if [ $VERSIONING = true ] ; then
+              #      echo "Enabling versioning for '$BUCKET'"
+              #      mc version enable minio/$BUCKET
+              #  elif [ $VERSIONING = false ] ; then
+              #      echo "Suspending versioning for '$BUCKET'"
+              #      mc version suspend minio/$BUCKET
+              #  fi
+              #else
+              #    echo "Bucket '$BUCKET' versioning unchanged."
+              #fi
+
+              # At this point, the bucket should exist, skip checking for existence
+              # Set policy on the bucket
+              echo "Setting policy of bucket '$BUCKET' to '$POLICY'."
+              mc policy set $POLICY minio/$BUCKET
+            }
+
             while [ -z "$(mc config host add minio ${MINIO_ENDPOINT} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY})" ] ; do echo 'Wait minio to startup...' && sleep 0.1; done;
-            {{- range $bucket := $.Values.buckets }}
-            mc mb --ignore-existsing minio/{{ $bucket }}
-            {{- end }}
+            {{ range $bucket_name, $bucket := $.Values.buckets }}
+            {{- $bucket_purge := ($bucket.purge | default false) -}}
+            {{- $bucket_policy := $bucket.policy | default "none" -}}
+            createBucket {{ $bucket_name }} {{ $bucket_policy }} {{ $bucket_purge }}
+            {{ end }}
         env:
         {{- include "minio-manager.minioAdminCredentialEnvs" $.Values.minioAdminCredentials | indent 8 }}
       restartPolicy: Never

--- a/charts/minio-manager/values.yaml
+++ b/charts/minio-manager/values.yaml
@@ -11,9 +11,13 @@ nameOverride: ""
 fullnameOverride: ""
 
 # List of buckets to create
-buckets: []
-# - bucket1
-# - bucket2
+buckets: {}
+#  bucket1: # name of the bucket to create
+#     policy: ""  # Set a policy for anonymous users on this bucket. Allowed policies are: [none, download, upload, public] (https://docs.min.io/docs/minio-client-complete-guide.html#policy)
+#     purge: false  # purge the bucket if already exists if set to true
+#  bucket2
+#     policy: ""
+#     purge: ""
 
 # List of users with their accesses
 users: []


### PR DESCRIPTION
Adding purge and policy options on bucket creation.
Note that versioning is not available with the current version of minio. In all cases, it is only available for distributed minio.
If the PR is merged, I'll create an issue about the versioning. The code is available, but currently commented out.