### PR TITLE
Fix create-user-job.yaml

### DIFF
--- a/charts/postgres-db-manager/templates/create-user-job.yaml
+++ b/charts/postgres-db-manager/templates/create-user-job.yaml
@@ -24,7 +24,7 @@ spec:
             if [ "$( psql -tAc "SELECT 1 FROM pg_roles where rolname='${USER}'" )" != '1' ]
             then
               echo "Creating ${USER} user on Postgresql"
-              psql -c "CREATE USER ${USER} WITH PASSWORD '${PASSWORD}';"
+              psql -c "CREATE USER '${USER}' WITH PASSWORD '${PASSWORD}';"
             else
               echo "User ${USER} already exists!"
             fi


### PR DESCRIPTION
Quote the username to not fail on usernames containing `-`