### PR TITLE
Add bucket versioning to the bucket creator container.

### DIFF
--- a/charts/minio-manager/Chart.yaml
+++ b/charts/minio-manager/Chart.yaml
@@ -10,9 +10,9 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.0.2
+appVersion: 0.0.3

--- a/charts/minio-manager/README.md
+++ b/charts/minio-manager/README.md
@@ -21,7 +21,7 @@ The user of this chart must validate the compatibility of the minio deployment a
 | Chart version  | Default minio client image             | Expected minio deployment              |
 |:---------------|:---------------------------------------|:---------------------------------------|
 |0.2.0           |[minio/mc:RELEASE.2020-04-04T05-28-55Z](https://github.com/minio/mc/releases/tag/RELEASE.2020-04-04T05-28-55Z)   |[minio/minio:RELEASE.2020-04-10T03-34-42Z](https://github.com/minio/minio/releases/tag/RELEASE.2020-04-10T03-34-42Z)|
-
+|0.3.0           |[minio/mc:RELEASE.2020-11-25T23-04-07Z](https://github.com/minio/mc/releases/tag/RELEASE.2020-11-25T23-04-07Z)   |[minio/minio:RELEASE.2020-12-03T05-49-24Z](https://github.com/minio/minio/releases/tag/RELEASE.2020-12-03T05-49-24Z)|
 
 ## Parameters
 

--- a/charts/minio-manager/README.md
+++ b/charts/minio-manager/README.md
@@ -18,10 +18,10 @@ To use the `versioning` option on bucket creation, the deployed minio must be [d
 The default minio client version used in this chart has been selected to work with the minio deployment we are using.
 The user of this chart must validate the compatibility of the minio deployment and the minio client used in this chart.
 
-| Chart version  | Default minio client image             | Expected minio deployment              |
-|:---------------|:---------------------------------------|:---------------------------------------|
-|0.2.0           |[minio/mc:RELEASE.2020-04-04T05-28-55Z](https://github.com/minio/mc/releases/tag/RELEASE.2020-04-04T05-28-55Z)   |[minio/minio:RELEASE.2020-04-10T03-34-42Z](https://github.com/minio/minio/releases/tag/RELEASE.2020-04-10T03-34-42Z)|
-|0.3.0           |[minio/mc:RELEASE.2020-11-25T23-04-07Z](https://github.com/minio/mc/releases/tag/RELEASE.2020-11-25T23-04-07Z)   |[minio/minio:RELEASE.2020-12-03T05-49-24Z](https://github.com/minio/minio/releases/tag/RELEASE.2020-12-03T05-49-24Z)|
+| Chart version  | Default minio client image                                                                                    | Expected minio deployment                                                                                          | Chart features |
+|:---------------|:--------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------|---------------|
+|0.2.0           |[minio/mc:RELEASE.2020-04-04T05-28-55Z](https://github.com/minio/mc/releases/tag/RELEASE.2020-04-04T05-28-55Z) |[minio/minio:RELEASE.2020-04-10T03-34-42Z](https://github.com/minio/minio/releases/tag/RELEASE.2020-04-10T03-34-42Z)| Users and policies management. Creation of buckets with policy and purge options.|
+|0.3.0           |[minio/mc:RELEASE.2020-11-25T23-04-07Z](https://github.com/minio/mc/releases/tag/RELEASE.2020-11-25T23-04-07Z) |[minio/minio:RELEASE.2020-12-03T05-49-24Z](https://github.com/minio/minio/releases/tag/RELEASE.2020-12-03T05-49-24Z)| Add versioning option to bucket creation |
 
 ## Parameters
 

--- a/charts/minio-manager/README.md
+++ b/charts/minio-manager/README.md
@@ -5,6 +5,8 @@
 This chart manages buckets, users and access rights for [Minio](https://min.io/) on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 This chart only handles the creation of these resources. It does not manage their deletions.
 
+To use the `versioning` option on bucket creation, the deployed minio must be [distributed](https://docs.min.io/docs/distributed-minio-quickstart-guide.html).
+
 ## Prerequisites
 
 - Kubernetes 1.12+
@@ -40,13 +42,14 @@ The following table lists the parameters of this chart.
 |`minioAdminCredentials.secretKeys.useSsl`        | Name of the secret key for use ssl field                                   |MINIO_USE_SSL               |
 |`image.repository`                               | Repository of the minio image                                              |minio/mc                    |
 |`image.pullPolicy`                               | Kubernetes image pull policy                                               |IfNotPresent                |
-|`image.tag`                                      | Tag of the minio image                                                     |RELEASE.2021-01-05T05-03-58Z|
+|`image.tag`                                      | Tag of the minio image                                                     |RELEASE.2020-11-25T23-04-07Z|
 |`imagePullSecrets`                               | List of kubertnetes image pull secrets                                     |                            |
 |`nameOverride`                                   | Override the name of the chart                                             |                            |
 |`fullnameOverride`                               | Override the full name of the chart and component                          |                            |
 |`buckets`                                        | Buckets to create as a YAML object. The key is the name of the bucket      |{}                          |
 |`buckets.[name].policy`                          | Policy applied on the bucket for anonymous users. Allowed policies are: [none, download, upload, public] (https://docs.min.io/docs/minio-client-complete-guide.html#policy) |none |
 |`buckets.[name].purge`                           | Purge the bucket if already existent if set to true                        |false                       |
+|`buckets.[name].versioning`                      | Select if the bucket should be versioned or not. If unset, the bucket versioning will be unchanged. https://docs.min.io/docs/minio-bucket-versioning-guide.html|"" |
 
 ## Local test
 

--- a/charts/minio-manager/ci/test-values.yaml
+++ b/charts/minio-manager/ci/test-values.yaml
@@ -7,6 +7,8 @@ buckets:
     purge: true
   bucket3:
     policy: upload
+  bucket4:
+    versioning: true
 
 # List of users with their accesses
 users:

--- a/charts/minio-manager/templates/minio-manager-global-job.yaml
+++ b/charts/minio-manager/templates/minio-manager-global-job.yaml
@@ -122,22 +122,17 @@ spec:
                 echo "Bucket '$BUCKET' already exists."
               fi
 
-              # Versioning feature available only from RELEASE.2020-07-11T06-07-16Z
-              # https://github.com/minio/minio/releases/tag/RELEASE.2020-07-11T06-07-16Z
-              # Currently using RELEASE.2020-04-04T05-28-55Z
-              # When updated, we can add back the following lines
-              # set versioning for bucket
-              #if [ ! -z $VERSIONING ] ; then
-              #  if [ $VERSIONING = true ] ; then
-              #      echo "Enabling versioning for '$BUCKET'"
-              #      mc version enable minio/$BUCKET
-              #  elif [ $VERSIONING = false ] ; then
-              #      echo "Suspending versioning for '$BUCKET'"
-              #      mc version suspend minio/$BUCKET
-              #  fi
-              #else
-              #    echo "Bucket '$BUCKET' versioning unchanged."
-              #fi
+              if [ ! -z $VERSIONING ] ; then
+                if [ $VERSIONING = true ] ; then
+                    echo "Enabling versioning for '$BUCKET'"
+                    mc version enable minio/$BUCKET
+                elif [ $VERSIONING = false ] ; then
+                    echo "Suspending versioning for '$BUCKET'"
+                    mc version suspend minio/$BUCKET
+                fi
+              else
+                  echo "Bucket '$BUCKET' versioning unchanged."
+              fi
 
               # At this point, the bucket should exist, skip checking for existence
               # Set policy on the bucket
@@ -148,8 +143,9 @@ spec:
             while [ -z "$(mc config host add minio ${MINIO_ENDPOINT} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY})" ] ; do echo 'Wait minio to startup...' && sleep 0.1; done;
             {{ range $bucket_name, $bucket := $.Values.buckets }}
             {{- $bucket_purge := ($bucket.purge | default false) -}}
-            {{- $bucket_policy := $bucket.policy | default "none" -}}
-            createBucket {{ $bucket_name }} {{ $bucket_policy }} {{ $bucket_purge }}
+            {{- $bucket_policy := ($bucket.policy | default "none") -}}
+            {{- $bucket_versioning := ($bucket.versioning | default "") }}
+            createBucket {{ $bucket_name }} {{ $bucket_policy }} {{ $bucket_purge }} {{ $bucket_versioning }}
             {{ end }}
         env:
         {{- include "minio-manager.minioAdminCredentialEnvs" $.Values.minioAdminCredentials | indent 8 }}

--- a/charts/minio-manager/values.yaml
+++ b/charts/minio-manager/values.yaml
@@ -4,7 +4,7 @@
 image:
   repository: minio/mc
   pullPolicy: IfNotPresent
-  tag: RELEASE.2020-04-04T05-28-55Z
+  tag: RELEASE.2020-11-25T23-04-07Z
 
 imagePullSecrets: []
 nameOverride: ""
@@ -15,7 +15,8 @@ buckets: {}
 #  bucket1: # name of the bucket to create
 #     policy: ""  # Set a policy for anonymous users on this bucket. Allowed policies are: [none, download, upload, public] (https://docs.min.io/docs/minio-client-complete-guide.html#policy)
 #     purge: false  # purge the bucket if already exists if set to true
-#  bucket2
+#     versioning: ""  # versioning of the bucket. Only available in erasure coded and distributed erasure coded setups (https://docs.min.io/docs/minio-bucket-versioning-guide.html)
+#  bucket2:
 #     policy: ""
 #     purge: ""
 


### PR DESCRIPTION
This PR is built on top of the PR #7 which you had reviewed.
I created this PR because I got slightly confused with the comment:
> Worth adding tags to this repo and keep a compatibility matrix with Minio version. We can release a new version compatible with bucket policies/RELEASE.2020-07-11T06-07-16Z next and choose which one to use on our projects.

This PR is to add the possibility to version buckets, which requires a newer version of the client, and the server must be in a distributed configuration.
But also note that this is not the only incompatibility: the policy creation with this version of the client does not work with the older version of the server we were using. So we really need to keep the client and server at compatible versions to work well.
Note 2: when minio is not in distributed mode, the bucket creation step is failing with the error
```
mc: <ERROR> Unable to enable versioning. A header you provided implies functionality that is not implemented.
```
I still have to try with a distributed configuration.

Now more about the comment: we are handling a github repository, not a helm chart repository, so the version of the chart cannot be really used by argo. In argo, we will just point to the git commit/tag to install it. So I do not know how we will manage cleanly a compatibility matrix, even more knowing that we can modify the minio client tag from the value file...

In the end, should I only merge the state from this PR? Should I merge both PRs one after the other?