### PR TITLE
Add the chart for job-scheduler

### DIFF
--- a/charts/job-scheduler/.helmignore
+++ b/charts/job-scheduler/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/job-scheduler/Chart.yaml
+++ b/charts/job-scheduler/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: job-scheduler
+description: A Helm chart for managing cron jobs.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.0.0

--- a/charts/job-scheduler/README.md
+++ b/charts/job-scheduler/README.md
@@ -1,0 +1,33 @@
+# Job-Scheduler
+
+This is a thin wrapper chart for generating Kubernetes `cronjob`s.
+
+Values file contains a top-level map named `jobs` that must be populated with nested maps of job definitions.
+
+The following values attributes are required:
+* `command`
+* `namespace`
+* `image.repo`
+* `schedule`
+
+## Attributes
+```
+  my_cronjob_1:
+    namespace: <namespace> (required)
+    schedule: <cron format scheduling spec or shortcuts> (required) e.g. "@hourly", "17 * * * *" etc
+    command: <list of command segments> (required) e.g. [ "/bin/sh", "-c" ]
+    args: <list of arguments to the command>. This can be used to define whole scripts via usage of `;` and multiline strings
+    envFrom: <list of env sources, same as Kubernetes spec envFrom>, e.g. - secretRef: ...
+    image:
+      repo: <image repository> (required)
+      tag: <image tag> default: 'latest'
+      pullSecrets: <list of image pull secrets> e.g. - name: my-ecr-secret
+    volumes:
+      - name: nfs-volume
+        nfs:
+          server: 192.168.1.43
+          path: /source_dir_on_nfs
+    volumeMounts:
+    - name: nfs-volume
+      mountPath: /mnt
+```

--- a/charts/job-scheduler/README.md
+++ b/charts/job-scheduler/README.md
@@ -5,10 +5,10 @@ This is a thin wrapper chart for generating Kubernetes `cronjob`s.
 Values file contains a top-level map named `jobs` that must be populated with nested maps of job definitions.
 
 The following values attributes are required:
-* `command`
 * `namespace`
-* `image.repo`
-* `schedule`
+* `job.command`
+* `job.image.repo`
+* `job.schedule`
 
 ## Attributes
 ```
@@ -17,7 +17,7 @@ The following values attributes are required:
     schedule: <cron format scheduling spec or shortcuts> (required) e.g. "@hourly", "17 * * * *" etc
     command: <list of command segments> (required) e.g. [ "/bin/sh", "-c" ]
     args: <list of arguments to the command>. This can be used to define whole scripts via usage of `;` and multiline strings
-    envFrom: <list of env sources, same as Kubernetes spec envFrom>, e.g. - secretRef: ...
+    secretRefs: <list of secrets to export into the container environment>, e.g. [ secret1, secret2 ]
     image:
       repo: <image repository> (required)
       tag: <image tag> default: 'latest'

--- a/charts/job-scheduler/templates/_helpers.tpl
+++ b/charts/job-scheduler/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "job-scheduler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "job-scheduler.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "job-scheduler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "job-scheduler.labels" -}}
+helm.sh/chart: {{ include "job-scheduler.chart" . }}
+{{ include "job-scheduler.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "job-scheduler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "job-scheduler.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "job-scheduler.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "job-scheduler.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/job-scheduler/templates/cronjob.yaml
+++ b/charts/job-scheduler/templates/cronjob.yaml
@@ -1,0 +1,49 @@
+{{ range $job, $attrs := .Values.jobs }}
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ $job | replace "_" "-" | quote }}
+  namespace: {{ (required "job.namespace is required!" $attrs.namespace) }}
+spec:
+  schedule: {{ (required "job.schedule is required!" $attrs.schedule) | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ $job | replace "_" "-" | quote }}
+            image: {{ printf "%s:%s" (required "job.image.repo is required!" $attrs.image.repo) ($attrs.image.tag | default "latest") }}
+
+            command:
+            {{- with $attrs.command }}
+            {{- toYaml (required "job.command is required!" .) | nindent 12 }}
+            {{ end }}
+
+            {{- with $attrs.args }}
+            args:
+            {{- toYaml . | nindent 12 }}
+            {{ end -}}
+
+            {{- with $attrs.envFrom }}
+            envFrom:
+            {{- toYaml . | nindent 12 }}
+            {{ end -}}
+
+            {{- with $attrs.volumeMounts }}
+            volumeMounts:
+            {{- toYaml . | nindent 12 }}
+            {{ end -}}
+
+          {{- with $attrs.volumes }}
+          volumes:
+          {{- toYaml . | nindent 10 }}
+          {{ end -}}
+
+          {{- with $attrs.image.pullSecrets }}
+          imagePullSecrets:
+          {{- toYaml . | nindent 10 }}
+          {{ end -}}
+
+{{ end }}

--- a/charts/job-scheduler/templates/cronjob.yaml
+++ b/charts/job-scheduler/templates/cronjob.yaml
@@ -5,7 +5,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ $job | replace "_" "-" | quote }}
-  namespace: {{ (required "job.namespace is required!" $attrs.namespace) }}
+  namespace: {{ required "namespace is required!" $.Values.namespace }}
 spec:
   schedule: {{ (required "job.schedule is required!" $attrs.schedule) | quote }}
   jobTemplate:
@@ -26,10 +26,13 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{ end -}}
 
-            {{- with $attrs.envFrom }}
+            {{- if $attrs.secretRefs }}
             envFrom:
-            {{- toYaml . | nindent 12 }}
-            {{ end -}}
+            {{- range $secret := $attrs.secretRefs }}
+              - secretRef:
+                name: {{ $secret | quote }}
+            {{- end }}
+            {{ end }}
 
             {{- with $attrs.volumeMounts }}
             volumeMounts:

--- a/charts/job-scheduler/values.yaml
+++ b/charts/job-scheduler/values.yaml
@@ -1,0 +1,65 @@
+# Format:
+# jobs:
+#   job_name_1:
+#     attribute_1: ...
+#     attribute_2: ...
+#     ...
+#   ...
+
+jobs:
+
+  # backup_postgresql:
+  #   namespace: postgresql
+  #   schedule: "17 * * * *"
+  #   command: 
+  #     - "/bin/sh"
+  #     - "-c"
+  #   args:
+  #     - df -h /mnt;
+  #       mkdir -p /mnt/backup_postgresql/combined;
+  #       old_dumps=$(find /mnt/backup_postgresql/prod -type f -name 'postgresql-*.7z' -mtime +180);
+  #       echo "removing old dumps ${old_dumps}";
+  #       rm -f $old_dumps;
+  #       echo starting a new backup;
+  #       if pg_dumpall | 7za a /mnt/backup_postgresql/prod/postgresql-$(date +%FT%H%M).7z -p${PG_BACKUP_PASSWORD} -si; then
+  #         echo "backup complete!"
+  #       else
+  #         echo "backup failed!"
+  #       fi
+  #   envFrom:
+  #     - secretRef:
+  #         name: backups
+  #   image:
+  #     repo: docker/busybox
+  #     tag: v1.2.6
+  #     pullSecrets: 
+  #     - name: ecr-registry-secret
+  #   volumes:
+  #     - name: nfs-volume
+  #       nfs:
+  #         server: nfs.volume.endpoint
+  #         path: /MOUNTED
+  #   volumeMounts:
+  #   - name: nfs-volume
+  #     mountPath: /mnt
+
+  # backup_minio_stage:
+  #   namespace: minio
+  #   schedule: "@hourly"
+  #   command:
+  #     - "/bin/sh"
+  #     - "-c"
+  #   args:
+  #     - df -h /mnt;
+  #       mkdir -p /mnt/backup_minio_stage/combined;
+  #       old_dumps=$(find /mnt/backup_minio_stage/prod -type f -name 'postgresql-*.7z' -mtime +180);
+  #       echo "removing old dumps ${old_dumps}";
+  #       rm -f $old_dumps;
+  #       echo starting a new backup;
+  #       echo TBC
+
+  #   image:
+  #     repo: docker/busybox
+  #     tag: v1.2.6
+  #     pullSecrets: 
+  #     - name: ecr-registry-secret

--- a/charts/job-scheduler/values.yaml
+++ b/charts/job-scheduler/values.yaml
@@ -1,3 +1,6 @@
+# The target namespace for the job(s)
+namespace: postgresql
+
 # Format:
 # jobs:
 #   job_name_1:
@@ -8,58 +11,36 @@
 
 jobs:
 
-  # backup_postgresql:
-  #   namespace: postgresql
-  #   schedule: "17 * * * *"
-  #   command: 
-  #     - "/bin/sh"
-  #     - "-c"
-  #   args:
-  #     - df -h /mnt;
-  #       mkdir -p /mnt/backup_postgresql/combined;
-  #       old_dumps=$(find /mnt/backup_postgresql/prod -type f -name 'postgresql-*.7z' -mtime +180);
-  #       echo "removing old dumps ${old_dumps}";
-  #       rm -f $old_dumps;
-  #       echo starting a new backup;
-  #       if pg_dumpall | 7za a /mnt/backup_postgresql/prod/postgresql-$(date +%FT%H%M).7z -p${PG_BACKUP_PASSWORD} -si; then
-  #         echo "backup complete!"
-  #       else
-  #         echo "backup failed!"
-  #       fi
-  #   envFrom:
-  #     - secretRef:
-  #         name: backups
-  #   image:
-  #     repo: docker/busybox
-  #     tag: v1.2.6
-  #     pullSecrets: 
-  #     - name: ecr-registry-secret
-  #   volumes:
-  #     - name: nfs-volume
-  #       nfs:
-  #         server: nfs.volume.endpoint
-  #         path: /MOUNTED
-  #   volumeMounts:
-  #   - name: nfs-volume
-  #     mountPath: /mnt
+  backup_postgresql:
+    schedule: "17 * * * *"
+    command: 
+      - "/bin/sh"
+      - "-c"
+    args:
+      - df -h /mnt;
+        mkdir -p /mnt/backup_postgresql/combined;
+        old_dumps=$(find /mnt/backup_postgresql/prod -type f -name 'postgresql-*.7z' -mtime +180);
+        echo "removing old dumps ${old_dumps}";
+        rm -f $old_dumps;
+        echo starting a new backup;
+        if pg_dumpall | 7za a /mnt/backup_postgresql/prod/postgresql-$(date +%FT%H%M).7z -p${PG_BACKUP_PASSWORD} -si; then
+          echo "backup complete!"
+        else
+          echo "backup failed!"
+        fi
+    secretRefs:
+      - backups
+    image:
+      repo: docker/busybox
+      tag: v1.2.6
+      pullSecrets: 
+      - name: ecr-registry-secret
+    volumes:
+      - name: nfs-volume
+        nfs:
+          server: nfs.volume.endpoint
+          path: /MOUNTED
+    volumeMounts:
+    - name: nfs-volume
+      mountPath: /mnt
 
-  # backup_minio_stage:
-  #   namespace: minio
-  #   schedule: "@hourly"
-  #   command:
-  #     - "/bin/sh"
-  #     - "-c"
-  #   args:
-  #     - df -h /mnt;
-  #       mkdir -p /mnt/backup_minio_stage/combined;
-  #       old_dumps=$(find /mnt/backup_minio_stage/prod -type f -name 'postgresql-*.7z' -mtime +180);
-  #       echo "removing old dumps ${old_dumps}";
-  #       rm -f $old_dumps;
-  #       echo starting a new backup;
-  #       echo TBC
-
-  #   image:
-  #     repo: docker/busybox
-  #     tag: v1.2.6
-  #     pullSecrets: 
-  #     - name: ecr-registry-secret


### PR DESCRIPTION
Just a thin wrapper chart to allow defining cronjobs declaratively. The initial use case is backups but it can be used for any kind of cronjob in the future.

Multiple instances can be rendered into a single cluster via `fullNameOverride` but I recommend having a single instance of the chart but multiple job definitions grouped and separated by sensible naming conventions.