### PR TITLE
Add source and target keys...

### DIFF
--- a/charts/postgres-db-sync/table2table_sync.sh
+++ b/charts/postgres-db-sync/table2table_sync.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 date;
 
-export INPUT="${INPUT_DB_NAME}:${INPUT_SCHEMA}.\"${INPUT_TABLE}\""
-export OUTPUT="${OUTPUT_DB_NAME}:${OUTPUT_SCHEMA}.\"${OUTPUT_TABLE}\""
+export INPUT="${INPUT_DB_NAME}:${INPUT_SCHEMA}.${INPUT_TABLE}"
+export OUTPUT="${OUTPUT_DB_NAME}:${OUTPUT_SCHEMA}.${OUTPUT_TABLE}"
 
 echo "Synchronize ${INPUT}";
 echo "to ${OUTPUT}";


### PR DESCRIPTION
to distinguish metrics of tables being synchronised in the same job. Also, create an epoch metric with the timestamp used to filter the records.