### PR TITLE
Correct typos around EOF

### DIFF
--- a/charts/postgres-db-table-sync/templates/copy-cronjob.yaml
+++ b/charts/postgres-db-table-sync/templates/copy-cronjob.yaml
@@ -42,13 +42,13 @@ spec:
                 -d $SOURCE_DB_NAME \
                 -U $SOURCE_DB_USER \
                 -p $SOURCE_DB_PORT \
-                -e <<EOF
+                -e << EOF
                 BEGIN;
                 {{- range $tableMapping:= $.Values.tableMappings }}
                 \copy {{ $tableMapping.inputTable }} TO '/tmp/{{ $tableMapping.inputTable }}.dump';
                 {{- end }}
                 COMMIT;
-                EOF;
+              EOF
               
               echo "Copy the tables to ${TARGET_DB_HOST}:${TARGET_DB_NAME}";
               PGPASSWORD=${TARGET_DB_PASSWORD} psql \
@@ -56,14 +56,14 @@ spec:
                 -d $TARGET_DB_NAME \
                 -U $TARGET_DB_USER \
                 -p $TARGET_DB_PORT \
-                -e <<EOF
+                -e << EOF
                 BEGIN;
                 {{- range $tableMapping:= $.Values.tableMappings }}
                 TRUNCATE TABLE {{ $tableMapping.outputTable }};
                 \copy {{ $tableMapping.outputTable }} FROM '/tmp/{{ $tableMapping.inputTable }}.dump';
                 {{- end }}
                 COMMIT;
-                EOF;
+              EOF
             env:
                 # Source DB 
               - name: SOURCE_DB_HOST


### PR DESCRIPTION
Need to remove prefixed spaces and trailing semi column.

I ran the job locally on a single table copy which logged:
```
Copy the following tables from 192.168.20.7:postgres:
  - mv_av_claims_history_counts to copied_mv_av

BEGIN;
BEGIN
COPY  mv_av_claims_history_counts TO STDOUT ;
COPY 9
COMMIT;
COMMIT
Copy the tables to 192.168.20.7:postgres
BEGIN;
BEGIN
TRUNCATE TABLE copied_mv_av;
TRUNCATE TABLE
COPY  copied_mv_av FROM STDIN ;
COPY 9
COMMIT;
COMMIT
```
And I validated that I could run the script multiple time, ensuring that the output has the same value as the source.