### PR TITLE
[#patch] Add db-copy-2

### DIFF
--- a/charts/postgres-db-copy-2/.helmignore
+++ b/charts/postgres-db-copy-2/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/postgres-db-copy-2/Chart.yaml
+++ b/charts/postgres-db-copy-2/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: postgres-db-copy-2
+description: A Helm chart to copy postgres tables from one db to another db using pg_dump and pg_restore, without schema or table creation.
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+maintainers:
+  - name: Ambiata
+    email: info@ambiata.com
+    url: www.ambiata.com

--- a/charts/postgres-db-copy-2/README.md
+++ b/charts/postgres-db-copy-2/README.md
@@ -1,0 +1,43 @@
+# Postgres DB copy II
+
+A chart to copy multiple postgres tables from one database to another one using pg_dump and pg_restore.
+The chart does not create shemas or table, instead it truncates tables and syncs data.
+
+This means any tables used here must already exist in the target database.
+
+It will truncate all tables, and then load the new data as a single transaction.
+
+## Parameters for this job   
+
+- Define the source db
+```yaml
+sourceDB:
+  host: ""
+  name: "postgres"
+  user: "postgres"
+  port: 5432
+  secret: ""
+  passwordKey: "PGPASSWORD"
+```
+
+- Define the target db
+```yaml
+targetDB:
+  host: ""
+  name: "postgres"
+  user: "postgres"
+  port: 5432
+  secret: ""
+  passwordKey: "PGPASSWORD"
+```
+
+- List the tables to copy
+```yaml
+tables: []
+```
+
+- Define when do you want to copy the tables
+```yaml
+cronjob:
+  schedule: "@daily"
+```

--- a/charts/postgres-db-copy-2/ci/test-values.yaml
+++ b/charts/postgres-db-copy-2/ci/test-values.yaml
@@ -1,0 +1,19 @@
+podAnnotations:
+  logging: logging-splunk
+
+sourceDB:
+  host: "my-release-3-postgresql"
+  name: "sourceDB"
+  user: "postgres"
+  secret: "my-release-3-postgresql"
+  passwordKey: postgresql-password
+
+targetDB:
+  host: "my-release-3-postgresql"
+  name: "targetDB"
+  user: "postgres"
+  secret: "my-release-3-postgresql"
+  passwordKey: postgresql-password
+
+tables:
+  - customers

--- a/charts/postgres-db-copy-2/templates/_helpers.tpl
+++ b/charts/postgres-db-copy-2/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "postgres-db-copy-2.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "postgres-db-copy-2.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "postgres-db-copy-2.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "postgres-db-copy-2.labels" -}}
+helm.sh/chart: {{ include "postgres-db-copy-2.chart" . }}
+{{ include "postgres-db-copy-2.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "postgres-db-copy-2.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "postgres-db-copy-2.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/postgres-db-copy-2/templates/copy-cronjob.yaml
+++ b/charts/postgres-db-copy-2/templates/copy-cronjob.yaml
@@ -1,0 +1,105 @@
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "postgres-db-copy-2.fullname" . }}
+  labels:
+    {{- include "postgres-db-copy-2.labels" . | nindent 4 }}
+spec:
+  schedule: {{ $.Values.cronjob.schedule | quote }}
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+         {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+         {{- end }}
+        spec:
+          restartPolicy: {{ $.Values.cronjob.restartPolicy }}
+          {{- if $.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml $.Values.imagePullSecrets | nindent 12 }}
+          {{- end }}
+          containers:
+          - name: postgres-to-postgres-copy-cronjob
+            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+            imagePullPolicy: {{ $.Values.image.pullPolicy }}
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+            
+              echo "Dump data for the following tables from ${SOURCE_DB_HOST}:${SOURCE_DB_NAME}:
+              {{- range $table := $.Values.tables }}
+                - {{ $table }}
+              {{- end }}
+              "
+            
+              # Create a data-only dump (custom format for pg_restore flexibility).
+              PGPASSWORD=${SOURCE_DB_PASSWORD} pg_dump -Fc \
+                --data-only \
+                --no-privileges \
+                --no-owner \
+                -h ${SOURCE_DB_HOST} \
+                -U ${SOURCE_DB_USER} \
+                -p ${SOURCE_DB_PORT} \
+                {{- range $table := $.Values.tables }}
+                -t {{ $table }} \
+                {{- end }}
+                ${SOURCE_DB_NAME} \
+                > /tmp/db.dump
+            
+              echo "Truncating target tables in ${TARGET_DB_HOST}:${TARGET_DB_NAME} prior to restore..."
+              {{- range $table := $.Values.tables }}
+              PGPASSWORD=${TARGET_DB_PASSWORD} psql \
+                -h ${TARGET_DB_HOST} \
+                -d ${TARGET_DB_NAME} \
+                -U ${TARGET_DB_USER} \
+                -p ${TARGET_DB_PORT} \
+                -v ON_ERROR_STOP=1 \
+                -c "TRUNCATE TABLE {{ $table }};"
+              {{- end }}
+            
+              echo "Restoring data into ${TARGET_DB_HOST}:${TARGET_DB_NAME}..."
+              PGPASSWORD=${TARGET_DB_PASSWORD} pg_restore \
+                --data-only \
+                --no-privileges \
+                --no-owner \
+                --single-transaction \
+                -h ${TARGET_DB_HOST} \
+                -d ${TARGET_DB_NAME} \
+                -U ${TARGET_DB_USER} \
+                -p ${TARGET_DB_PORT} \
+                /tmp/db.dump ;
+            env:
+                # Source DB 
+              - name: SOURCE_DB_HOST
+                value: {{ required "Source db host is required" .Values.sourceDB.host }}
+              - name: SOURCE_DB_NAME
+                value: {{ .Values.sourceDB.name }}
+              - name: SOURCE_DB_USER
+                value: {{ .Values.sourceDB.user }}
+              - name: SOURCE_DB_PORT
+                value: {{ .Values.sourceDB.port | quote }}
+              - name: SOURCE_DB_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ required "Source db secret is required" .Values.sourceDB.secret }}
+                    key: {{ .Values.sourceDB.passwordKey }}
+                # Target DB 
+              - name: TARGET_DB_HOST
+                value: {{ required "Target db host is required" .Values.targetDB.host }}
+              - name: TARGET_DB_NAME
+                value: {{ .Values.targetDB.name }}
+              - name: TARGET_DB_USER
+                value: {{ .Values.targetDB.user }}
+              - name: TARGET_DB_PORT
+                value: {{ .Values.targetDB.port | quote }}
+              - name: TARGET_DB_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ required "Target db secret is required" .Values.targetDB.secret }}
+                    key: {{ .Values.targetDB.passwordKey }}

--- a/charts/postgres-db-copy-2/values.yaml
+++ b/charts/postgres-db-copy-2/values.yaml
@@ -1,0 +1,39 @@
+# Default values for postgres-db-copy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: "docker.io/bitnamilegacy/postgresql"
+  pullPolicy: IfNotPresent
+  tag: "11.7.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+cronjob:
+  schedule: "@daily"
+  restartPolicy: "Never"
+
+sourceDB:
+  host: ""
+  name: "postgres"
+  user: "postgres"
+  port: 5432
+  secret: ""
+  passwordKey: "PGPASSWORD"
+
+targetDB:
+  host: ""
+  name: "postgres"
+  user: "postgres"
+  port: 5432
+  secret: ""
+  passwordKey: "PGPASSWORD"
+
+tables: []
+
+# create the schema if not exists
+schemasToCreate: []


### PR DESCRIPTION
Runs the same way as db-copy, but truncates tables instead of recreating them during each run.